### PR TITLE
Support OTP 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.3.0
-    - otp_release: 19.3
-      elixir: 1.4.0
+    - otp_release: 20.0
+      elixir: 1.4.5
 
 sudo: false
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
   end
 
   defp deps do
-    [{:rustler, "~> 0.9"},
+    [{:rustler, "~> 0.10.1"},
 
      # docs
      {:ex_doc, "~> 0.14", only: :docs},

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "^0.14"
+rustler = "^0.15.1"
 
 html5ever = "0.16.0"
 xml5ever = "0.6.0"


### PR DESCRIPTION
Update to Rustler v0.10.1/0.15.1 (which supports OTP 20) and update .travis.yml to test OTP 20.