### PR TITLE
Update Cargo.toml to use the current Rustler

### DIFF
--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "^0.15.1"
+rustler = "^0.16"
 
 html5ever = "0.20.0"
 xml5ever = "0.10.0"


### PR DESCRIPTION
Update Cargo.toml to use the current Rustler that supports the latest ERTS versions.

Making this change locally works well.