### PR TITLE
Support OTP 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.3.0
-    - otp_release: 20.2
-      elixir: 1.6.3
+    - otp_release: 21.0
+      elixir: 1.6.6
 
 sudo: false
 

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
 
   defp deps do
     [
-      {:rustler, "~> 0.17.0"},
+      {:rustler, "~> 0.18.0"},
 
       # docs
       {:ex_doc, "~> 0.14.0", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,5 @@
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
-  "rustler": {:hex, :rustler, "0.17.1", "2b4f120daf411b4eebd8cad6cb68f7d519dc409ca9e70daa8856d1d37b13e203", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.18.0", "db4bd0c613d83a1badc31be90ddada6f9821de29e4afd15c53a5da61882e4f2d", [:mix], [], "hexpm"},
 }

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "^0.17"
+rustler = "^0.18"
 
 html5ever = "0.20.0"
 xml5ever = "0.10.0"


### PR DESCRIPTION
Update to Rustler `v0.18`, which supports OTP 21, and update `.travis.yml` to test with OTP 21.