### PR TITLE
Support Elixir 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,20 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.3.0
+    - otp_release: 19.3
+      elixir: 1.4.0
+    - otp_release: 20.0
+      elixir: 1.4.5
+    - otp_release: 20.0
+      elixir: 1.5.1
+    - otp_release: 20.2
+      elixir: 1.5.1
+    - otp_release: 20.2
+      elixir: 1.6.3
     - otp_release: 21.0
       elixir: 1.6.6
+    - otp_release: 21.0
+      elixir: 1.7.3
 
 sudo: false
 


### PR DESCRIPTION
Update .travis.yml to include Elixir 1.7, as well as previous versions.