### PR TITLE
Remove support for Elixir 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: elixir
 
 matrix:
   include:
-    - otp_release: 19.0
-      elixir: 1.3.0
     - otp_release: 19.3
       elixir: 1.4.0
     - otp_release: 20.0

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
       name: "MeeseeksHtml5ever",
       version: @version,
       description: description(),
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       deps: deps(),
       package: package(),
       source_url: "https://github.com/mischov/meeseeks_html5ever",


### PR DESCRIPTION
Removes support for Elixir 1.3 and OTP 19.0.

Minimum supported combination is now Elixir 1.4 and OTP 19.3.