### PR TITLE
Support OTP 22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,18 @@ language: elixir
 
 matrix:
   include:
-    - otp_release: 19.3
-      elixir: 1.4.0
     - otp_release: 20.0
-      elixir: 1.4.5
+      elixir: 1.6.0
     - otp_release: 20.0
-      elixir: 1.5.1
-    - otp_release: 20.2
-      elixir: 1.6.3
+      elixir: 1.9.0
     - otp_release: 21.0
       elixir: 1.6.6
     - otp_release: 21.0
-      elixir: 1.7.3
-    - otp_release: 21.0
-      elixir: 1.8.1
+      elixir: 1.9.0
+    - otp_release: 22.0
+      elixir: 1.7.0
+    - otp_release: 22.0
+      elixir: 1.9.0
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Originally a fork of Hansihe's [html5ever_elixir](https://github.com/hansihe/htm
 
 ## Compatibility
 
-Meeseeks_Html5ever is tested with a minimum combination of Elixir 1.4.0 and Erlang/OTP 19.3, and a maximum combination of Elixir 1.8.1 and Erlang/OTP 21.0.
+Meeseeks_Html5ever is tested with a minimum combination of Elixir 1.6.0 and Erlang/OTP 20.0, and a maximum combination of Elixir 1.9.0 and Erlang/OTP 22.0.
 
 ## Dependencies
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
       name: "MeeseeksHtml5ever",
       version: @version,
       description: description(),
-      elixir: "~> 1.4",
+      elixir: "~> 1.6",
       deps: deps(),
       package: package(),
       source_url: "https://github.com/mischov/meeseeks_html5ever",
@@ -40,7 +40,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
 
   defp deps do
     [
-      {:rustler, "~> 0.20.0"},
+      {:rustler, "~> 0.21.0"},
 
       # docs
       {:ex_doc, ex_doc_version(), only: :docs, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -6,5 +6,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "rustler": {:hex, :rustler, "0.20.0", "6b2cc8149700a7b1df2226dbe273ec1f9449318cad3bd3b5b68125a4cf1f438b", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
+  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
 }

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "0.20"
+rustler = "0.21"
 
 html5ever = "0.22"
 xml5ever = "0.12"


### PR DESCRIPTION
Elixir 1.4, Elixir 1.5, and OTP 19 are no longer supported (Rustler now required a minimum version of 1.6).

Minimum tested combination is now Elixir 1.6.0 and OTP 20.0, and the maximum tested combination is Elixir 1.9.0 and OTP 22.0.

- Update Rustler to 0.21.0 which supports OTP22
- Remove Elixir 1.4, Elixir 1.5, and OTP 19 from `.travis.yml`
- Add Elixir 1.9 and OTP 22 to `.travis.yml`