### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.12.0 (2019-09-08)
+
+### Compatability
+
+  * No longer support Elixir 1.4, Elixir 1.5, or Erlang/OTP 19 (minumum tested compatiblity is now Elixir 1.6 and Erlang/OTP 20)
+  * Support Elixir 1.9 and Erlang/OTP 22
+
+### Fixes
+
+  * Update to Rustler `v0.21`, which supports Erlang/OTP 22 (but requires a minumum Elixir version of 1.6)
+
 ## v0.11.1 (2019-06-28)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ensure Rust is installed, then add Meeseeks_Html5ever to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.11.1"}
+    {:meeseeks_html5ever, "~> 0.12.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MeeseeksHtml5ever.Mixfile do
   use Mix.Project
 
-  @version "0.11.1"
+  @version "0.12.0"
 
   def project do
     [

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meeseeks_html5ever_nif"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Meeseeks <mmischov@gmail.com>"]
 
 [lib]


### PR DESCRIPTION
### Compatability

  * No longer support Elixir 1.4, Elixir 1.5, or Erlang/OTP 19 (minumum tested compatiblity is now Elixir 1.6 and Erlang/OTP 20)
  * Support Elixir 1.9 and Erlang/OTP 22

### Fixes

  * Update to Rustler `v0.21`, which supports Erlang/OTP 22 (but requires a minumum Elixir version of 1.6)