### PR TITLE
Add support for OTP 24, upgrade rustler to v0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       elixir: 1.7.0
     - otp_release: 22.0
       elixir: 1.9.0
+    - otp_release: 24.0
+      elixir: 1.12.2
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Compatibility
+
+  * Support Elixir 1.12 and Erlang/OTP 24
+  * Suppress warnings on x86_64-apple-darwin
+  * Use Rustler v0.22
+
 ## v0.12.1 (2019-09-09)
 
 ### Enhancements
@@ -8,7 +16,7 @@
 
 ## v0.12.0 (2019-09-08)
 
-### Compatability
+### Compatibility
 
   * No longer support Elixir 1.4, Elixir 1.5, or Erlang/OTP 19 (minumum tested compatiblity is now Elixir 1.6 and Erlang/OTP 20)
   * Support Elixir 1.9 and Erlang/OTP 22

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Originally a fork of Hansihe's [html5ever_elixir](https://github.com/hansihe/htm
 
 ## Compatibility
 
-Meeseeks_Html5ever requires a minimum combination of Elixir 1.6.0 and Erlang/OTP 20.0, and is tested with a maximum combination of Elixir 1.9.0 and Erlang/OTP 22.0.
+Meeseeks_Html5ever requires a minimum combination of Elixir 1.6.0 and Erlang/OTP 20.0, and is tested with a maximum combination of Elixir 1.12.0 and Erlang/OTP 24.0.
 
 ## Dependencies
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,10 @@
 use Mix.Config
+
+config :meeseeks_html5ever, MeeseeksHtml5ever.Native,
+  path: "native/meeseeks_html5ever_nif",
+  cargo: :system,
+  default_features: false,
+  features: [],
+  mode: :release,
+  otp_app: :meeseeks_html5ever,
+  crate: :meeseeks_html5ever_nif

--- a/lib/meeseeks_html5ever/native.ex
+++ b/lib/meeseeks_html5ever/native.ex
@@ -1,7 +1,7 @@
 defmodule MeeseeksHtml5ever.Native do
   @moduledoc false
 
-  use Rustler, otp_app: :meeseeks_html5ever, crate: "meeseeks_html5ever_nif"
+  use Rustler, otp_app: :meeseeks_html5ever, crate: :meeseeks_html5ever_nif
 
   defmodule NifNotLoadedError do
     @moduledoc false

--- a/mix.exs
+++ b/mix.exs
@@ -16,21 +16,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
       docs: docs(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      compilers: [:rustler] ++ Mix.compilers(),
-      rustler_crates: rustler_crates()
-    ]
-  end
-
-  def rustler_crates do
-    [
-      meeseeks_html5ever_nif: [
-        path: "native/meeseeks_html5ever_nif",
-        cargo: :system,
-        default_features: false,
-        features: [],
-        mode: :release
-        # mode: (if Mix.env == :prod, do: :release, else: :debug),
-      ]
+      compilers: Mix.compilers()
     ]
   end
 
@@ -40,7 +26,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
 
   defp deps do
     [
-      {:rustler, "~> 0.21.0"},
+      {:rustler, "~> 0.22.0-rc.1"},
 
       # docs
       {:ex_doc, ex_doc_version(), only: :docs, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,12 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.15", "2c7f924bf495ec1f65bd144b355d0949a05a254d0ec561740308a54946a67888", [:mix], [{:earmark_parser, ">= 1.4.13", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "3b1209b85bc9f3586f370f7c363f6533788fb4e51db23aa79565875e7f9999ee"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "9dbe1ce1d711dc5362e3b3280e92989ad61413ce423bc4e9f76d5fcc51ab8d6b"},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
-  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.22.0-rc.1", "46668ba0c5f97e8aa978ee965c473f7d4ab5560182ebf2c3bb1cf18956f92afb", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "c0eb17d6c52885153218e89b2877122cdb094aeefd191647f78094022f3b9101"},
+  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/native/meeseeks_html5ever_nif/.cargo/config
+++ b/native/meeseeks_html5ever_nif/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["dylib"]
 [dependencies]
 rustler = "0.21"
 
-html5ever = "0.22"
+html5ever = "0.22.0-rc.1"
 xml5ever = "0.12"
 markup5ever = "0.7"
 tendril = "0.4"


### PR DESCRIPTION
This upgrades rustler to v0.22.0-rc.1 to allow compilation under OTP 24.

Also addresses #34.