### PR TITLE
Update library implementation for rustler v0.22 (contd.)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,15 @@ defmodule MeeseeksHtml5ever.Mixfile do
     [
       maintainers: ["Mischov"],
       licenses: ["MIT", "Apache-2.0"],
-      files: ["lib", "native", "mix.exs", "README.md", "LICENSE-MIT", "LICENSE-APACHE"],
+      files: [
+        "lib",
+        "native",
+        "priv/.gitkeep",
+        "mix.exs",
+        "README.md",
+        "LICENSE-MIT",
+        "LICENSE-APACHE"
+      ],
       links: %{"GitHub" => "https://github.com/mischov/meeseeks_html5ever"}
     ]
   end

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -9,9 +9,9 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "0.21"
+rustler = "0.22.0-rc.1"
 
-html5ever = "0.22.0-rc.1"
+html5ever = "0.22"
 xml5ever = "0.12"
 markup5ever = "0.7"
 tendril = "0.4"

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Meeseeks <mmischov@gmail.com>"]
 [lib]
 name = "meeseeks_html5ever_nif"
 path = "src/lib.rs"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.22.0-rc.1"

--- a/native/meeseeks_html5ever_nif/src/flat_dom.rs
+++ b/native/meeseeks_html5ever_nif/src/flat_dom.rs
@@ -336,39 +336,39 @@ impl TreeSink for FlatDom {
 // NIF Encoding
 
 mod atoms {
-    rustler_atoms! {
-        atom nil;
+    atoms! {
+        nil,
 
-        atom parent;
-        atom id;
-        atom content;
-        atom name;
-        atom public;
-        atom system;
-        atom namespace;
-        atom tag;
-        atom attributes;
-        atom children;
-        atom target;
-        atom data;
+        parent,
+        id,
+        content,
+        name,
+        public,
+        system,
+        namespace,
+        tag,
+        attributes,
+        children,
+        target,
+        data,
 
-        atom type_ = "type";
-        atom script;
-        atom style;
-        atom cdata;
+        type_ = "type",
+        script,
+        style,
+        cdata,
 
-        atom id_counter;
-        atom roots;
-        atom nodes;
+        id_counter,
+        roots,
+        nodes,
 
-        atom __struct__;
-        atom document = "Elixir.Meeseeks.Document";
-        atom document_comment = "Elixir.Meeseeks.Document.Comment";
-        atom document_data = "Elixir.Meeseeks.Document.Data";
-        atom document_doctype = "Elixir.Meeseeks.Document.Doctype";
-        atom document_element = "Elixir.Meeseeks.Document.Element";
-        atom document_pi = "Elixir.Meeseeks.Document.ProcessingInstruction";
-        atom document_text = "Elixir.Meeseeks.Document.Text";
+        __struct__,
+        document = "Elixir.Meeseeks.Document",
+        document_comment = "Elixir.Meeseeks.Document.Comment",
+        document_data = "Elixir.Meeseeks.Document.Data",
+        document_doctype = "Elixir.Meeseeks.Document.Doctype",
+        document_element = "Elixir.Meeseeks.Document.Element",
+        document_pi = "Elixir.Meeseeks.Document.ProcessingInstruction",
+        document_text = "Elixir.Meeseeks.Document.Text",
     }
 }
 


### PR DESCRIPTION
Continuation of #35, fixes issues related to a botched upgrade, and completes the upgrade.

This also adds GitHub actions, which should replace Travis. 