### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0 (2021-06-24)
+
 ### Compatibility
 
   * No longer support Elixir 1.6 or Erlang/OTP20

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ensure Rust is installed, then add Meeseeks_Html5ever to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.12.1"}
+    {:meeseeks_html5ever, "~> 0.13.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MeeseeksHtml5ever.Mixfile do
   use Mix.Project
 
-  @version "0.12.1"
+  @version "0.13.0"
 
   def project do
     [

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meeseeks_html5ever_nif"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Meeseeks <mmischov@gmail.com>"]
 
 [lib]


### PR DESCRIPTION
### Compatibility

  * No longer support Elixir 1.6 or Erlang/OTP20
  * Support Elixir 1.12 and Erlang/OTP 24
  * Suppress warnings on x86_64-apple-darwin
  * Use Rustler v0.22