### PR TITLE
Support compilation on M1 Macbooks

### DIFF
--- a/native/meeseeks_html5ever_nif/.cargo/config
+++ b/native/meeseeks_html5ever_nif/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
PR for #46.

- Adjusts the cargo config for compilation on new Macbooks with m1 processor

To do before merging:

- [x] Test compilation on old Macbook with this config