### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.14.0 (2023-03-26)
+
 ### Compatibility
 
   * No longer support Elixir versions under 1.12 or Erlang/OTP versions under 23.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ensure Rust is installed, then add Meeseeks_Html5ever to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.13.1"}
+    {:meeseeks_html5ever, "~> 0.14.0"}
   ]
 end
 ```
@@ -40,7 +40,7 @@ If you want to force compilation you will need to have the Rust compiler [instal
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.13.1"},
+    {:meeseeks_html5ever, "~> 0.14.0"},
     {:rustler, ">= 0.0.0", optional: true}
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
 
   @description "Meeseeks-specific NIF binding of html5ever using Rustler"
   @source_url "https://github.com/mischov/meeseeks_html5ever"
-  @version "0.13.1"
+  @version "0.14.0"
 
   def project do
     [

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meeseeks_html5ever_nif"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Mischov <mmischov@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
### Compatibility

  * No longer support Elixir versions under 1.12 or Erlang/OTP versions under 23.0
  * Support Elixir 1.13 and 1.14 and Erlang/OTP 25.0

### Enhancements

  * Use Rust 2018 edition
  * Update to Rustler `v0.27`
  * Update to latest versions of Html5ever and Xml5ever
  * Use `rustler_precompiled` to precompile NIFs

### Fixes

  * Fix Rust formatting and clippy issues