### PR TITLE
Add RUSTLER_NIF_VERSION to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
 
     runs-on: ${{ matrix.job.os }}
 
+    env:
+      RUSTLER_NIF_VERSION: ${{ matrix.nif }}
+
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
Error seen in Meeseeks (segfault during compilation with OTP 23) similar to https://github.com/philss/rustler_precompiled/issues/23, which was caused by `RUSTLER_NIF_VERSION` not being passed into cross.

In Meeseek's case cross is not being used, but I am not seeing `RUSTLER_NIF_VERSION` being set anywhere in `philss/rustler-precompiled-action@v1.0.0` so I am going to try setting it directly in `release.yml`.