### PR TITLE
Release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.14.3 (2023-03-27)
+
+### Fixes
+
+  * Add `RUSTLER_NIF_VERSION` to release workflow
+
 ## v0.14.2 (2023-03-26)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ensure Rust is installed, then add Meeseeks_Html5ever to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.14.2"}
+    {:meeseeks_html5ever, "~> 0.14.3"}
   ]
 end
 ```
@@ -40,7 +40,7 @@ If you want to force compilation you will need to have the Rust compiler [instal
 ```elixir
 def deps do
   [
-    {:meeseeks_html5ever, "~> 0.14.2"},
+    {:meeseeks_html5ever, "~> 0.14.3"},
     {:rustler, ">= 0.0.0", optional: true}
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MeeseeksHtml5ever.Mixfile do
 
   @description "Meeseeks-specific NIF binding of html5ever using Rustler"
   @source_url "https://github.com/mischov/meeseeks_html5ever"
-  @version "0.14.2"
+  @version "0.14.3"
 
   def project do
     [

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meeseeks_html5ever_nif"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["Mischov <mmischov@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
### Fixes

  * Add `RUSTLER_NIF_VERSION` to release workflow