### PR TITLE
Add NIF version info to support precompiling both 2.15 and 2.16

### DIFF
--- a/lib/meeseeks_html5ever/native.ex
+++ b/lib/meeseeks_html5ever/native.ex
@@ -16,7 +16,8 @@ defmodule MeeseeksHtml5ever.Native do
         env_config[:build_from_source],
     targets:
       Enum.uniq(["aarch64-unknown-linux-musl" | RustlerPrecompiled.Config.default_targets()]),
-    version: version
+    version: version,
+    nif_versions: ["2.15", "2.16"]
 
   def parse_html(_binary), do: err()
   def parse_xml(_binary), do: err()

--- a/native/meeseeks_html5ever_nif/Cargo.toml
+++ b/native/meeseeks_html5ever_nif/Cargo.toml
@@ -18,3 +18,8 @@ markup5ever = "0.11"
 
 tendril = "0.4"
 lazy_static = "1.4"
+
+[features]
+default = ["nif_version_2_15"]
+nif_version_2_15 = ["rustler/nif_version_2_15"]
+nif_version_2_16 = ["rustler/nif_version_2_16"]


### PR DESCRIPTION
Relates to issue #66, as well as the currently failing release workflow.